### PR TITLE
Improve test coverage to 86%

### DIFF
--- a/app/tests/unit/bedrockService.test.js
+++ b/app/tests/unit/bedrockService.test.js
@@ -1,0 +1,39 @@
+const sendMock = jest.fn();
+
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn(),
+  ConverseCommand: jest.fn()
+}));
+
+jest.mock('../../src/utils/logger', () => ({
+  debug: jest.fn()
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  const br = require('@aws-sdk/client-bedrock-runtime');
+  br.BedrockRuntimeClient.mockImplementation(function(){ this.send = sendMock; });
+  br.ConverseCommand.mockImplementation(function(params){ this.params = params; });
+  br.BedrockRuntimeClient.mockClear();
+  br.ConverseCommand.mockClear();
+  sendMock.mockReset();
+  delete process.env.AWS_REGION;
+  delete process.env.MODEL_ID;
+});
+
+test('describeImage sends command with correct params', async () => {
+  process.env.AWS_REGION = 'sa-east-1';
+  process.env.MODEL_ID = 'model-id';
+  jest.resetModules();
+  const br = require('@aws-sdk/client-bedrock-runtime');
+  br.BedrockRuntimeClient.mockImplementation(function(){ this.send = sendMock; });
+  br.ConverseCommand.mockImplementation(function(params){ this.params = params; });
+  const { describeImage } = require('../../src/services/bedrockService');
+  const bytes = Buffer.from('abcd');
+  sendMock.mockResolvedValue('ok');
+  const result = await describeImage(bytes, 'png');
+  expect(br.BedrockRuntimeClient).toHaveBeenCalledWith({ region: 'sa-east-1' });
+  expect(br.ConverseCommand).toHaveBeenCalledWith(expect.objectContaining({ modelId: 'model-id' }));
+  expect(sendMock).toHaveBeenCalled();
+  expect(result).toBe('ok');
+});

--- a/app/tests/unit/constants.test.js
+++ b/app/tests/unit/constants.test.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+describe('config constants', () => {
+  afterEach(() => {
+    jest.resetModules();
+    delete process.env.AWS_REGION;
+    delete process.env.MODEL_ID;
+  });
+
+  test('uses environment variables when defined', () => {
+    process.env.AWS_REGION = 'sa-east-1';
+    process.env.MODEL_ID = 'test-model';
+    const constants = require('../../src/config/constants');
+    expect(constants.DEFAULT_REGION).toBe('sa-east-1');
+    expect(constants.DEFAULT_MODEL).toBe('test-model');
+  });
+
+  test('falls back to default values', () => {
+    const constants = require('../../src/config/constants');
+    expect(constants.DEFAULT_REGION).toBe('us-east-1');
+    expect(constants.DEFAULT_MODEL).toBe('anthropic.claude-3-sonnet-2024-04-09-v1:0');
+  });
+});

--- a/app/tests/unit/imageHandler.test.js
+++ b/app/tests/unit/imageHandler.test.js
@@ -1,0 +1,51 @@
+const { InvalidImageError } = require('../../src/errors/customErrors');
+
+jest.mock('../../src/services/imageProcessingService', () => ({
+  parseBody: jest.fn()
+}));
+
+jest.mock('../../src/services/bedrockService', () => ({
+  describeImage: jest.fn()
+}));
+
+jest.mock('../../src/utils/logger', () => ({
+  error: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn()
+}));
+
+const { handler } = require('../../src/handlers/imageHandler');
+const { parseBody } = require('../../src/services/imageProcessingService');
+const { describeImage } = require('../../src/services/bedrockService');
+const logger = require('../../src/utils/logger');
+
+describe('imageHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns description on success', async () => {
+    parseBody.mockReturnValue({ imageBytes: Buffer.from('data'), format: 'png' });
+    describeImage.mockResolvedValue({ description: 'ok' });
+    const result = await handler({});
+    expect(describeImage).toHaveBeenCalledWith(expect.any(Buffer), 'png');
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ description: 'ok' });
+  });
+
+  test('returns 400 for InvalidImageError', async () => {
+    parseBody.mockImplementation(() => { throw new InvalidImageError('bad'); });
+    const result = await handler({});
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).message).toBe('bad');
+  });
+
+  test('returns 500 for unexpected error', async () => {
+    parseBody.mockReturnValue({ imageBytes: Buffer.from('a'), format: 'png' });
+    describeImage.mockRejectedValue(new Error('fail'));
+    const result = await handler({});
+    expect(logger.error).toHaveBeenCalled();
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body).message).toBe('fail');
+  });
+});

--- a/app/tests/unit/imageProcessingService.test.js
+++ b/app/tests/unit/imageProcessingService.test.js
@@ -40,3 +40,151 @@ test('parseBody handles json with base64', () => {
 test('parseBody throws InvalidImageError for missing body', () => {
   expect(() => parseBody({ headers: {}, body: null })).toThrow(InvalidImageError);
 });
+
+// Testes adicionais para melhorar cobertura
+test('parseBody handles JSON without image field', () => {
+  const event = {
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ data: 'some data' }),
+    isBase64Encoded: false,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles invalid JSON', () => {
+  const event = {
+    headers: { 'content-type': 'application/json' },
+    body: 'invalid json{',
+    isBase64Encoded: false,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles JSON with invalid base64 image', () => {
+  const event = {
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ image: 'invalid-base64-data' }),
+    isBase64Encoded: false,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles direct base64 with invalid image format', () => {
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: 'aW52YWxpZCBpbWFnZSBkYXRh', // "invalid image data" em base64
+    isBase64Encoded: true,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles direct base64 with error', () => {
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: 'invalid-base64!@#$%',
+    isBase64Encoded: true,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles binary string with invalid image format', () => {
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: 'invalid binary image data',
+    isBase64Encoded: false,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles binary string with error', () => {
+  // Mock Buffer.from to throw an error
+  const originalBufferFrom = Buffer.from;
+  Buffer.from = jest.fn().mockImplementation((data, encoding) => {
+    if (encoding === 'binary') {
+      throw new Error('Binary encoding error');
+    }
+    return originalBufferFrom(data, encoding);
+  });
+
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: 'some string data',
+    isBase64Encoded: false,
+  };
+  
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+  
+  // Restore original Buffer.from
+  Buffer.from = originalBufferFrom;
+});
+
+test('parseBody handles valid binary string', () => {
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: pngBuffer.toString('binary'),
+    isBase64Encoded: false,
+  };
+  const result = parseBody(event);
+  expect(Buffer.isBuffer(result.imageBytes)).toBe(true);
+  expect(result.format).toBe('png');
+});
+
+test('parseBody handles direct base64 decoding error', () => {
+  // Test para cobrir linha 69 - catch do direct base64
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: 'invalid-base64-chars-!@#$%^&*()',
+    isBase64Encoded: true,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody throws error for invalid image format after processing', () => {
+  // Test para cobrir linha 97 - validação final falha
+  // Usar dados que passam na decodificação mas falham na validação de formato
+  const invalidImageData = Buffer.from('This is not an image file').toString('base64');
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: invalidImageData,
+    isBase64Encoded: true,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody uses Content-Type header with capital C', () => {
+  const event = {
+    headers: { 'Content-Type': 'image/jpeg' },
+    body: pngBase64,
+    isBase64Encoded: true,
+  };
+  const result = parseBody(event);
+  expect(Buffer.isBuffer(result.imageBytes)).toBe(true);
+});
+
+test('parseBody uses default content-type when headers are missing', () => {
+  const event = {
+    body: pngBase64,
+    isBase64Encoded: true,
+  };
+  const result = parseBody(event);
+  expect(Buffer.isBuffer(result.imageBytes)).toBe(true);
+});
+
+test('parseBody handles base64 decoding exception', () => {
+  // Força um erro específico no Buffer.from para cobrir linha 69
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: '%invalid%base64%',
+    isBase64Encoded: true,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});
+
+test('parseBody handles empty body string', () => {
+  const event = {
+    headers: { 'content-type': 'image/png' },
+    body: '',
+    isBase64Encoded: false,
+  };
+  expect(() => parseBody(event)).toThrow(InvalidImageError);
+});

--- a/app/tests/unit/imageValidator.extra.test.js
+++ b/app/tests/unit/imageValidator.extra.test.js
@@ -1,0 +1,41 @@
+const {
+  isValidPng,
+  isValidImageFormat,
+  detectImageFormat,
+  getFormatFromContentType
+} = require('../../src/utils/imageValidator');
+
+describe('imageValidator additional cases', () => {
+  test('isValidPng validates header', () => {
+    const valid = Buffer.from([0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A]);
+    const invalid = Buffer.from([0x00,0x11,0x22,0x33]);
+    expect(isValidPng(valid)).toBe(true);
+    expect(isValidPng(invalid)).toBe(false);
+  });
+
+  test('isValidImageFormat detects jpeg gif webp and rejects others', () => {
+    const jpeg = Buffer.from([0xFF,0xD8,0xFF,0xE0,0,0,0,0]);
+    const gif = Buffer.from([0x47,0x49,0x46,0x38,0,0,0,0]);
+    const webp = Buffer.from([0x52,0x49,0x46,0x46,0,0,0,0,0x57,0x45,0x42,0x50]);
+    expect(isValidImageFormat(jpeg)).toBe(true);
+    expect(isValidImageFormat(gif)).toBe(true);
+    expect(isValidImageFormat(webp)).toBe(true);
+    expect(isValidImageFormat(Buffer.from('bad'))).toBe(false);
+  });
+
+  test('detectImageFormat handles all formats and fallback', () => {
+    const jpeg = Buffer.from([0xFF,0xD8,0xFF,0xE0]);
+    const gif = Buffer.from([0x47,0x49,0x46,0x38]);
+    const webp = Buffer.from([0x52,0x49,0x46,0x46,0,0,0,0,0x57,0x45,0x42,0x50]);
+    expect(detectImageFormat(jpeg)).toBe('jpeg');
+    expect(detectImageFormat(gif)).toBe('gif');
+    expect(detectImageFormat(webp)).toBe('webp');
+    expect(detectImageFormat(Buffer.from([0,0,0,0]))).toBe('png');
+  });
+
+  test('getFormatFromContentType returns appropriate or fallback', () => {
+    expect(getFormatFromContentType('image/gif')).toBe('gif');
+    expect(getFormatFromContentType('image/unknown')).toBe('png');
+    expect(getFormatFromContentType(undefined)).toBe('png');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for config constants
- test error handling and success paths in image handler
- mock AWS SDK to test bedrock service
- cover additional branches in image validator

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_686088e1dd188322a4bd521febab026c